### PR TITLE
ArgumentException Fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,6 @@ Or just use the ThunderStore mod loader.
 
 ## Changelog
 
-### Version 1.0.0
+### Version 1.0.1 ArgumentException Fix
 
 - Release

--- a/TerminalHistory/Plugin.cs
+++ b/TerminalHistory/Plugin.cs
@@ -48,7 +48,7 @@ namespace TerminalHistory
 
 			if(_commands.Count > SIZE) 
 			{
-				_commands.RemoveRange(SIZE + 1, _commands.Count - SIZE);
+				_commands.RemoveRange(SIZE, _commands.Count - SIZE);
 			}
 
 			_index = -1;

--- a/TerminalHistory/Plugin.cs
+++ b/TerminalHistory/Plugin.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 
 namespace TerminalHistory
 {
-	[BepInPlugin("atomic.terminalhistory", "Terminal History", "1.0.0")]
+	[BepInPlugin("atomic.terminalhistory", "Terminal History", "1.0.1")]
 	[BepInDependency("atomic.terminalapi", MinimumDependencyVersion: "1.3.0")]
 	public partial class Plugin : BaseUnityPlugin
 	{


### PR DESCRIPTION
```
[Error  : Unity Log] ArgumentException: Offset and length were out of bounds for the array or count is greater than the number of elements from index to the end of the source collection.
Stack trace:
System.Collections.Generic.List`1[T].RemoveRange (System.Int32 index, System.Int32 count) (at <787acc3c9a4c471ba7d971300105af24>:IL_0020)
TerminalHistory.Plugin.OnTerminalSubmit (System.Object sender, TerminalApi.Events.Events+TerminalParseSentenceEventArgs e) (at <fc5b35beaf3e401ba211c2f66fb1975a>:IL_0064)
TerminalApi.Events.Events.ParsePlayerSentence (Terminal& __instance, TerminalNode __result) (at <cb393fe4e95a46eea61611279c027f11>:IL_0052)
(wrapper dynamic-method) Terminal.DMD<Terminal::ParsePlayerSentence>(Terminal)
(wrapper dynamic-method) Terminal.DMD<Terminal::OnSubmit>(Terminal)
UnityEngine.Events.InvokableCall.Invoke () (at <e27997765c1848b09d8073e5d642717a>:IL_0010)
UnityEngine.Events.UnityEvent`1[T0].Invoke (T0 arg0) (at <e27997765c1848b09d8073e5d642717a>:IL_0049)
TMPro.TMP_InputField.SendOnEndEdit () (at <830d2f4cda924be69883be03cc68e010>:IL_000E)
TMPro.TMP_InputField.ReleaseSelection () (at <830d2f4cda924be69883be03cc68e010>:IL_001B)
TMPro.TMP_InputField.DeactivateInputField (System.Boolean clearSelection) (at <830d2f4cda924be69883be03cc68e010>:IL_00B0)
TMPro.TMP_InputField.OnUpdateSelected (UnityEngine.EventSystems.BaseEventData eventData) (at <830d2f4cda924be69883be03cc68e010>:IL_007C)
UnityEngine.EventSystems.ExecuteEvents.Execute (UnityEngine.EventSystems.IUpdateSelectedHandler handler, UnityEngine.EventSystems.BaseEventData eventData) (at <281a675b48d344e28f9941b2777fd620>:IL_0000)
UnityEngine.EventSystems.ExecuteEvents.Execute[T] (UnityEngine.GameObject target, UnityEngine.EventSystems.BaseEventData eventData, UnityEngine.EventSystems.ExecuteEvents+EventFunction`1[T1] functor) (at <281a675b48d344e28f9941b2777fd620>:IL_0067)
UnityEngine.EventSystems.EventSystem:Update()
```