### PR TITLE
Change Terminal History Functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -125,6 +125,7 @@ $tf/
 _ReSharper*/
 *.[Rr]e[Ss]harper
 *.DotSettings.user
+*.idea
 
 # JustCode is a .NET coding add-in
 .JustCode

--- a/TerminalHistory/Plugin.cs
+++ b/TerminalHistory/Plugin.cs
@@ -40,12 +40,16 @@ namespace TerminalHistory
         {
 
 	        if (_commands.First?.Value == e.SubmittedText)
+	        {
 		        return;
+	        }
 
 	        _commands.AddFirst(e.SubmittedText);
 	        
 	        if (_commands.Count > SIZE)
+	        {
 		        _commands.RemoveLast();
+	        }
         }
 
         private void OnTerminalExited(object sender, TerminalEventArgs e)
@@ -81,7 +85,9 @@ namespace TerminalHistory
         private void OnDownArrowPerformed(InputAction.CallbackContext context)
         {
 	        if (_commands.Count == 0 || !Terminal.terminalInUse)
+	        {
 		        return;
+	        }
 
 	        switch (--_index)
 	        {
@@ -91,7 +97,10 @@ namespace TerminalHistory
 		        case 0:
 			        LinkedListNode<string> firstCommand = _commands.First;
 			        if (firstCommand == null)
+			        {
 				        return;
+			        }
+
 			        SetTerminalText(firstCommand.Value);
 			        break;
 		        default:
@@ -103,9 +112,11 @@ namespace TerminalHistory
 
         private void OnUpArrowPerformed(InputAction.CallbackContext context)
         {
-	        if (!Terminal.terminalInUse || _commands.Count <= 0) 
+	        if (!Terminal.terminalInUse || _commands.Count <= 0)
+	        {
 		        return;
-	        
+	        }
+
 	        if (_index >= _commands.Count)
 	        {
 		        _index = _commands.Count - 1;
@@ -129,7 +140,9 @@ namespace TerminalHistory
 		private string GetValueFromIndex(int index)
 		{
 			if (index <= 0)
+			{
 				return _commands.First != null ? _commands.First.Value : string.Empty;
+			}
 
 			int count = _commands.Count;
 			if (index >= count)

--- a/TerminalHistory/TerminalHistory.csproj
+++ b/TerminalHistory/TerminalHistory.csproj
@@ -21,32 +21,39 @@
     <PackageReference Include="BepInEx.PluginInfoProps" Version="2.*" />
     <PackageReference Include="NotAtomicBomb.TerminalApi" Version="1.3.0" />
   </ItemGroup>
-  
+
   <ItemGroup Condition="'$(TargetFramework.TrimEnd(`0123456789`))' == 'net'">
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="all" />
   </ItemGroup>
-  
+
   <ItemGroup>
     <Reference Include="Assembly-CSharp">
       <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Lethal Company\Lethal Company_Data\Managed\Assembly-CSharp.dll</HintPath>
+      <Private>false</Private>
     </Reference>
     <Reference Include="netstandard">
       <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Lethal Company\Lethal Company_Data\Managed\netstandard.dll</HintPath>
+      <Private>false</Private>
     </Reference>
     <Reference Include="Unity.InputSystem">
       <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Lethal Company\Lethal Company_Data\Managed\Unity.InputSystem.dll</HintPath>
+      <Private>false</Private>
     </Reference>
     <Reference Include="Unity.Netcode.Runtime">
       <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Lethal Company\Lethal Company_Data\Managed\Unity.Netcode.Runtime.dll</HintPath>
+      <Private>false</Private>
     </Reference>
     <Reference Include="Unity.TextMeshPro">
       <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Lethal Company\Lethal Company_Data\Managed\Unity.TextMeshPro.dll</HintPath>
+      <Private>false</Private>
     </Reference>
     <Reference Include="UnityEngine">
       <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Lethal Company\Lethal Company_Data\Managed\UnityEngine.dll</HintPath>
+      <Private>false</Private>
     </Reference>
     <Reference Include="UnityEngine.CoreModule">
       <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Lethal Company\Lethal Company_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
+      <Private>false</Private>
     </Reference>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Functional Changes:
- Mod remembers your history across network sessions / terminal instances ([Easily removable / changeable](https://github.com/JustArion/TerminalHistory/blob/main/TerminalHistory/Plugin.cs#L75))
- Down arrow doesn't erase your current line if history is latest. ([Shown here](https://github.com/JustArion/TerminalHistory/blob/main/TerminalHistory/Plugin.cs#L95))
Previously if the `_index` was 0 or -1 and you pressed DownArrow your current line would be erased. (The proposal is more in line with how a real terminal should work). The implementation is not 100% ideal and leaves room for improvement. eg. If you move the index up say x times and then starts typing, the down arrow should be at index -1 since thats your new baseline. Example of this can be found [here](https://cdn.discordapp.com/attachments/1166785753481760829/1182678725414899722/Dawn_Files_62a4455b-bb89-41b7-ae38-4cc36c9d1fb1.gif?ex=65859265&is=65731d65&hm=114c9de46504c90970e4d0d36681babf961b43eab8f8be8c8d818e966fc90c32&)
- Terminal Functionality changed on how the history is added and removed.

`Before:` 
```
1. Foo (Added)
2. Foo 
3. Bar (Added)
4. Foo 
```
`After:`
```
1. Foo (Added)
2. Foo 
3. Bar (Added)
4. Foo  (Added)
```
This is more in line with normal terminal functionality